### PR TITLE
address some compiler warnings as of 9 February's 1.8.0-nightly

### DIFF
--- a/src/number_streams.rs
+++ b/src/number_streams.rs
@@ -7,7 +7,6 @@ const U64_BYTES: usize = 8;
 
 macro_rules! number_stream(
     ($name:ident, $number_type:ty, $bytes_in_type:expr) => (
-#[allow(raw_pointer_derive)]
 #[derive(Debug,Copy,Clone)]
 struct $name<'a> {
     start: *const $number_type,

--- a/src/number_streams.rs
+++ b/src/number_streams.rs
@@ -8,7 +8,7 @@ const U64_BYTES: usize = 8;
 macro_rules! number_stream(
     ($name:ident, $number_type:ty, $bytes_in_type:expr) => (
 #[derive(Debug,Copy,Clone)]
-struct $name<'a> {
+pub struct $name<'a> {
     start: *const $number_type,
     end: *const $number_type,
     marker: PhantomData<&'a ()>


### PR DESCRIPTION
(I happened to notice some compiler warnings fly by while upgrading my nightly toolchain for [one of my projects](https://github.com/zackmdavis/Leafline), and thought I would send you these trivial patches. There were also a few more warnings concerning [custom hasher stabilization](https://github.com/rust-lang/rust/pull/31081), which are not addressed in this pull request.)