### PR TITLE
Implement Clone for RandomXxHashBuilder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,7 @@ impl Hasher for XxHash {
     }
 }
 
+#[derive(Clone)]
 pub struct RandomXxHashBuilder(u64);
 
 impl RandomXxHashBuilder {


### PR DESCRIPTION
Absence of `Clone` makes it unusable for me and for anyone who wants to clone `HashMap` directly or indirectly.