### PR TITLE
Add support for serialization/deserialization using serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,11 @@ license = "MIT"
 
 [dependencies]
 rand = ">= 0.3.10, < 0.7"
+serde = { version = "1.0", features = ["derive"], optional = true}
+
+[dev-dependencies]
+serde_json = "1.0"
+
+[features]
+serialize = ["serde"]
+


### PR DESCRIPTION
This pull requests adds support for serializing/deserializing the hasher using serde.

My concrete use-case is that I have a `HashMap` that I'd like to serialize to disk and read back in later.
I understand that this functionality is rarely needed, so I made it completely optional by using a feature-gate.