### PR TITLE
Add methods for getting total_len and seed, reorder Hasher impl

### DIFF
--- a/src/sixty_four.rs
+++ b/src/sixty_four.rs
@@ -268,6 +268,14 @@ impl XxHash64 {
 
         hash
     }
+
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    pub fn total_len(&self) -> u64 {
+        self.total_len
+    }
 }
 
 impl Default for XxHash64 {
@@ -277,12 +285,12 @@ impl Default for XxHash64 {
 }
 
 impl Hasher for XxHash64 {
-    fn write(&mut self, bytes: &[u8]) {
-        XxHash64::write(self, bytes)
-    }
-
     fn finish(&self) -> u64 {
         XxHash64::finish(self)
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        XxHash64::write(self, bytes)
     }
 }
 

--- a/src/thirty_two.rs
+++ b/src/thirty_two.rs
@@ -243,6 +243,14 @@ impl XxHash32 {
 
         hash
     }
+
+    pub fn seed(&self) -> u32 {
+        self.seed
+    }
+
+    pub fn total_len(&self) -> u32 {
+        self.total_len
+    }
 }
 
 impl Default for XxHash32 {
@@ -252,12 +260,12 @@ impl Default for XxHash32 {
 }
 
 impl Hasher for XxHash32 {
-    fn write(&mut self, bytes: &[u8]) {
-        XxHash32::write(self, bytes)
-    }
-
     fn finish(&self) -> u64 {
         u64::from(XxHash32::finish(self))
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        XxHash32::write(self, bytes)
     }
 }
 


### PR DESCRIPTION
Adds public methods for getting `total_len` and `seed`, also some cosmetic changes. 
 
+ Reorder Hasher trait impls to match documented order