### PR TITLE
[WIP] upgrade to stable xxh3 (v0.8.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 
 [dependencies]
 cfg-if = { version = "0.1", default-features = false }
-static_assertions = { version = "1.0", default-features = false }
+static_assertions = { version = "1.1", default-features = false }
 rand = { version = ">= 0.3.10, < 0.8", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true}
 digest = { version = "0.9", default-features = false, optional = true  }

--- a/comparison/src/c_xxhash.rs
+++ b/comparison/src/c_xxhash.rs
@@ -16,17 +16,17 @@ mod ffi {
     }
 
     extern "C" {
-        pub fn XXH32(input: *const c_void, length: size_t, seed: u32) -> XXH32_hash_t;
-        pub fn XXH64(input: *const c_void, length: size_t, seed: u64) -> XXH64_hash_t;
+        pub fn XXH32(input: *const c_void, length: size_t, seed: XXH32_hash_t) -> XXH32_hash_t;
+        pub fn XXH64(input: *const c_void, length: size_t, seed: XXH64_hash_t) -> XXH64_hash_t;
         pub fn XXH3_64bits_withSeed(
-            data: *const ::std::os::raw::c_void,
-            len: usize,
-            seed: ::std::os::raw::c_ulonglong,
+            data: *const c_void,
+            len: size_t,
+            seed: XXH64_hash_t,
         ) -> XXH64_hash_t;
         pub fn XXH3_128bits_withSeed(
-            data: *const ::std::os::raw::c_void,
-            len: usize,
-            seed: ::std::os::raw::c_ulonglong,
+            data: *const c_void,
+            len: size_t,
+            seed: XXH64_hash_t,
         ) -> XXH128_hash_t;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ mod digest_support;
 
 pub use crate::sixty_four::XxHash64;
 pub use crate::thirty_two::XxHash32;
-pub use crate::xxh3::{Hash128 as Xxh3Hash128, Hash64 as Xxh3Hash64};
+pub use crate::xxh3::{Hash128 as Xxh3Hash128, Hash64 as Xxh3Hash64, HasherExt};
 
 /// A backwards compatibility type alias. Consider directly using
 /// `XxHash64` instead.


### PR DESCRIPTION
As #39 mentioned, we need upgrade to stable xxh3, align to [xxHash3 v0.8.0](https://github.com/Cyan4973/xxHash/releases/tag/v0.8.0).

- [x] 64-bit variant 
  - [x] hash64
  - [x] hash64_with_seed
  - [x] hash64_with_secret
- [x] 128-bit variant 
  - [x] hash128
  - [x] hash128_with_seed
  - [x] hash128_with_secret
- [ ] Streaming API
  - [ ] Hash64
  - [ ] Hash128
- [ ] SIMD implementations
  - [ ] Generic
  - [ ] SSE2
  - [ ] AVX2