### PR TITLE
Change http to https in README's version badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Rust implementation of the [XXHash] algorithm.
 
-[![Build Status](https://travis-ci.org/shepmaster/twox-hash.svg)](https://travis-ci.org/shepmaster/twox-hash) [![Current Version](http://meritbadge.herokuapp.com/twox-hash)](https://crates.io/crates/twox-hash)
+[![Build Status](https://travis-ci.org/shepmaster/twox-hash.svg)](https://travis-ci.org/shepmaster/twox-hash) [![Current Version](https://meritbadge.herokuapp.com/twox-hash)](https://crates.io/crates/twox-hash)
 
 [Documentation](https://docs.rs/twox-hash/)
 


### PR DESCRIPTION
Otherwise the badge may not load as a browser may refuse to load http content on a https website.