### PR TITLE
Fix clippy lints

### DIFF
--- a/src/sixty_four.rs
+++ b/src/sixty_four.rs
@@ -53,7 +53,7 @@ impl XxCore {
             current_value = current_value.wrapping_add(value);
             current_value = current_value.rotate_left(31);
             current_value.wrapping_mul(PRIME_1)
-        };
+        }
 
         // By drawing these out, we can avoid going back and forth to
         // memory. It only really helps for large files, when we need

--- a/src/thirty_two.rs
+++ b/src/thirty_two.rs
@@ -58,7 +58,7 @@ impl XxCore {
             current_value = current_value.wrapping_add(value);
             current_value = current_value.rotate_left(13);
             current_value.wrapping_mul(PRIME_1)
-        };
+        }
 
         // By drawing these out, we can avoid going back and forth to
         // memory. It only really helps for large files, when we need

--- a/src/xxh3.rs
+++ b/src/xxh3.rs
@@ -463,7 +463,7 @@ fn hash_len_17to128_64bits(data: &[u8], len: usize, secret: &[u8], seed: u64) ->
     }
 
     acc = acc
-        .wrapping_add(mix_16bytes(data, &secret[..], seed))
+        .wrapping_add(mix_16bytes(data, &secret, seed))
         .wrapping_add(mix_16bytes(&data[len - 16..], &secret[16..], seed));
 
     avalanche(acc)
@@ -1222,7 +1222,7 @@ fn hash_len_17to128_128bits(data: &[u8], len: usize, secret: &[u8], seed: u64) -
         acc2 = acc2.wrapping_add(mix_16bytes(&data[len - 32..], &secret[48..], seed));
     }
 
-    acc1 = acc1.wrapping_add(mix_16bytes(data, &secret[..], seed));
+    acc1 = acc1.wrapping_add(mix_16bytes(data, &secret, seed));
     acc2 = acc2.wrapping_add(mix_16bytes(&data[len - 16..], &secret[16..], seed));
 
     let low64 = acc1.wrapping_add(acc2);


### PR DESCRIPTION
redundant_semicolons, redundant_slicing