### PR TITLE
Update cfg if 1.0 and rand to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 [dependencies]
 cfg-if = { version = "1.0", default-features = false }
 static_assertions = { version = "1.0", default-features = false }
-rand = { version = ">= 0.3.10, < 0.8", optional = true }
+rand = { version = ">= 0.3.10, < 0.9", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true}
 digest = { package = "digest", version = "0.8", default-features = false, optional = true  }
 digest_0_9 = { package = "digest", version = "0.9", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/twox-hash/"
 license = "MIT"
 
 [dependencies]
-cfg-if = { version = "0.1", default-features = false }
+cfg-if = { version = "1.0", default-features = false }
 static_assertions = { version = "1.0", default-features = false }
 rand = { version = ">= 0.3.10, < 0.8", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true}


### PR DESCRIPTION
Bumps cfg-if to 1.0, and allows building against rand 0.8.