### PR TITLE
Use 1.0 for cfg-if

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ documentation = "https://docs.rs/twox-hash/"
 license = "MIT"
 
 [dependencies]
-cfg-if = { version = ">= 0.1, < 2", default-features = false }
+cfg-if = { version = "1.0", default-features = false }
 static_assertions = { version = "1.0", default-features = false }
 rand = { version = ">= 0.3.10, < 0.9", optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true}
-digest = { package = "digest", version = "0.8", default-features = false, optional = true  }
+serde = { version = "1.0", features = ["derive"], optional = true }
+digest = { package = "digest", version = "0.8", default-features = false, optional = true }
 digest_0_9 = { package = "digest", version = "0.9", default-features = false, optional = true }
 digest_0_10 = { package = "digest", version = "0.10", default-features = false, optional = true }
 


### PR DESCRIPTION
cfg-if 1.0 is almost 2 years old at this point so I don't feel there is a reason to support pre-1.0 versions any longer. This change is meant to workaround a cargo bug where cargo will non-deterministically change the version back and forth between 0.1 and 1.0 if there is at least one more dependency on the 0.1 version, even for lockfile updates that don't directly touch cfg-if. Obviously this isn't critical, just a papercut.

Resolves: #85 