### PR TITLE
Add program to create hashes of strings given to the CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,20 @@ documentation = "https://docs.rs/twox-hash/"
 
 license = "MIT"
 
+[[bin]]
+name = "hash_file"
+path = "src/bin/hash_file.rs"
+
+[[bin]]
+name = "hash_string"
+path = "src/bin/hash_string.rs"
+
 [dependencies]
 cfg-if = { version = ">= 0.1, < 2", default-features = false }
 static_assertions = { version = "1.0", default-features = false }
 rand = { version = ">= 0.3.10, < 0.9", optional = true }
-serde = { version = "1.0", features = ["derive"], optional = true}
-digest = { package = "digest", version = "0.8", default-features = false, optional = true  }
+serde = { version = "1.0", features = ["derive"], optional = true }
+digest = { package = "digest", version = "0.8", default-features = false, optional = true }
 digest_0_9 = { package = "digest", version = "0.9", default-features = false, optional = true }
 digest_0_10 = { package = "digest", version = "0.10", default-features = false, optional = true }
 

--- a/src/bin/hash_string.rs
+++ b/src/bin/hash_string.rs
@@ -1,0 +1,12 @@
+use std::env;
+use std::hash::Hasher;
+use twox_hash::XxHash64;
+
+fn main() {
+    for arg in env::args().skip(1) {
+        let mut hasher = XxHash64::with_seed(0);
+        hasher.write(arg.as_bytes());
+
+        println!("{:16x}   {}", hasher.finish(), arg);
+    }
+}


### PR DESCRIPTION
This PR introduces the code for a second binary that will interpret the arguments given via the CLI as strings instead of paths and creates the hash value of the string. 