### PR TITLE
Add std::io::Write support to hashers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 //! A Rust implementation of the [XXHash] algorithm.
 //!
 //! [XXHash]: https://github.com/Cyan4973/xxHash
@@ -14,22 +16,22 @@
 //! assert_eq!(hash.get(&42), Some(&"the answer"));
 //! ```
 //!
-//! ### With a random seed
-//!
-//! ```rust
-//! use std::collections::HashMap;
-//! use twox_hash::RandomXxHashBuilder64;
-//!
-//! let mut hash: HashMap<_, _, RandomXxHashBuilder64> = Default::default();
-//! hash.insert(42, "the answer");
-//! assert_eq!(hash.get(&42), Some(&"the answer"));
-//! ```
+#[cfg_attr(feature = "std", doc = r##"
+### With a random seed
 
-#![no_std]
+```rust
+use std::collections::HashMap;
+use twox_hash::RandomXxHashBuilder64;
+
+let mut hash: HashMap<_, _, RandomXxHashBuilder64> = Default::default();
+hash.insert(42, "the answer");
+assert_eq!(hash.get(&42), Some(&"the answer"));
+```
+"##)]
 
 extern crate alloc;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "std"))]
 extern crate std;
 
 use core::{marker::PhantomData, mem};

--- a/src/xxh3.rs
+++ b/src/xxh3.rs
@@ -141,6 +141,23 @@ impl Hasher for Hash64 {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::io::Write for Hash64 {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Hasher::write(self, buf);
+        Ok(buf.len())
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        Hasher::write(self, buf);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 /// Calculates the 128-bit hash.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
 #[derive(Clone, Default)]
@@ -176,6 +193,23 @@ impl HasherExt for Hash128 {
     #[inline(always)]
     fn finish_ext(&self) -> u128 {
         self.0.digest128()
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Write for Hash128 {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        Hasher::write(self, buf);
+        Ok(buf.len())
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        Hasher::write(self, buf);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Adds std::io::Write support to allow easy streaming using the `std::io::Write` interface, like the `digest` crate.

This should also fix testing with --no-default-features (which I needed to validate not breaking tests without no_std).