### PR TITLE
Added optional support for the mem-dbg crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0", features = ["derive"], optional = true}
 digest = { package = "digest", version = "0.8", default-features = false, optional = true  }
 digest_0_9 = { package = "digest", version = "0.9", default-features = false, optional = true }
 digest_0_10 = { package = "digest", version = "0.10", default-features = false, optional = true }
+mem_dbg = {git="https://github.com/LucaCappelletti94/mem_dbg-rs", optional = true, branch="alloc"}
 
 [dev-dependencies]
 serde_json = "1.0"
@@ -30,3 +31,4 @@ serde_json = "1.0"
 default = ["std"]
 serialize = ["serde"]
 std = ["rand"]
+mem_dbg = ["dep:mem_dbg", "std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"], optional = true}
 digest = { package = "digest", version = "0.8", default-features = false, optional = true  }
 digest_0_9 = { package = "digest", version = "0.9", default-features = false, optional = true }
 digest_0_10 = { package = "digest", version = "0.10", default-features = false, optional = true }
-mem_dbg = {git="https://github.com/LucaCappelletti94/mem_dbg-rs", optional = true, branch="alloc"}
+mem_dbg = {version = "0.2.4", optional=true}
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! assert_eq!(hash.get(&42), Some(&"the answer"));
 //! ```
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub type XxHash = XxHash64;
 /// `RandomXxHashBuilder64` instead.
 pub type RandomXxHashBuilder = RandomXxHashBuilder64;
 
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 /// An unaligned buffer with iteration support for `UnalignedItem`.
 struct UnalignedBuffer<'a, T> {
     buf: &'a [u8],

--- a/src/sixty_four.rs
+++ b/src/sixty_four.rs
@@ -13,6 +13,7 @@ pub const PRIME_4: u64 = 9_650_029_242_287_828_579;
 pub const PRIME_5: u64 = 2_870_177_450_012_600_261;
 
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 #[derive(Copy, Clone, PartialEq)]
 struct XxCore {
     v1: u64,
@@ -23,6 +24,7 @@ struct XxCore {
 
 /// Calculates the 64-bit hash.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct XxHash64 {
     total_len: u64,
@@ -125,9 +127,11 @@ impl core::fmt::Debug for XxCore {
 #[derive(Debug, Copy, Clone, Default, PartialEq)]
 #[repr(align(8))]
 #[cfg_attr(feature = "serialize", serde(transparent))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 struct AlignToU64<T>(T);
 
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 #[derive(Debug, Copy, Clone, Default, PartialEq)]
 struct Buffer {
     #[cfg_attr(feature = "serialize", serde(rename = "buffer"))]

--- a/src/std_support.rs
+++ b/src/std_support.rs
@@ -4,6 +4,7 @@ pub mod sixty_four {
     use rand::{self, Rng};
 
     #[derive(Clone)]
+    #[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
     /// Constructs a randomized seed and reuses it for multiple hasher instances.
     pub struct RandomXxHashBuilder64(u64);
 
@@ -34,6 +35,7 @@ pub mod thirty_two {
     use rand::{self, Rng};
 
     #[derive(Clone)]
+    #[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
     /// Constructs a randomized seed and reuses it for multiple hasher instances. See the usage warning on `XxHash32`.
     pub struct RandomXxHashBuilder32(u32);
 
@@ -64,6 +66,7 @@ pub mod xxh3 {
     use rand::{self, Rng};
 
     #[derive(Clone)]
+    #[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
     /// Constructs a randomized seed and reuses it for multiple hasher instances.
     pub struct RandomHashBuilder64(u64);
 
@@ -88,6 +91,7 @@ pub mod xxh3 {
     }
 
     #[derive(Clone)]
+    #[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
     /// Constructs a randomized seed and reuses it for multiple hasher instances.
     pub struct RandomHashBuilder128(u64);
 

--- a/src/thirty_two.rs
+++ b/src/thirty_two.rs
@@ -13,6 +13,7 @@ pub const PRIME_4: u32 = 668_265_263;
 pub const PRIME_5: u32 = 374_761_393;
 
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 #[derive(Copy, Clone, PartialEq)]
 struct XxCore {
     v1: u32,
@@ -28,6 +29,7 @@ struct XxCore {
 /// 32-bit number, leaving the upper bits as 0. This means it is
 /// unlikely to be correct to use this in places like a `HashMap`.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct XxHash32 {
     total_len: u64,
@@ -115,9 +117,11 @@ impl core::fmt::Debug for XxCore {
 #[derive(Debug, Copy, Clone, Default, PartialEq)]
 #[repr(align(4))]
 #[cfg_attr(feature = "serialize", serde(transparent))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 struct AlignToU32<T>(T);
 
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 #[derive(Debug, Copy, Clone, Default, PartialEq)]
 struct Buffer {
     #[cfg_attr(feature = "serialize", serde(rename = "buffer"))]

--- a/src/xxh3.rs
+++ b/src/xxh3.rs
@@ -116,6 +116,7 @@ pub fn hash128_with_secret(data: &[u8], secret: &[u8]) -> u128 {
 
 /// Calculates the 64-bit hash.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 #[derive(Clone, Default)]
 pub struct Hash64(State);
 
@@ -143,6 +144,7 @@ impl Hasher for Hash64 {
 
 /// Calculates the 128-bit hash.
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 #[derive(Clone, Default)]
 pub struct Hash128(State);
 
@@ -203,6 +205,7 @@ const SECRET: Secret = Secret([
 
 #[repr(align(64))]
 #[derive(Clone)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 struct Secret([u8; SECRET_DEFAULT_SIZE]);
 
 const_assert_eq!(mem::size_of::<Secret>() % 16, 0);
@@ -243,6 +246,7 @@ cfg_if! {
             }
         }
 
+        #[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
         struct SecretVisitor;
 
         impl<'de> serde::de::Visitor<'de> for SecretVisitor {
@@ -288,16 +292,19 @@ cfg_if! {
     if #[cfg(target_feature = "avx2")] {
         #[repr(align(32))]
         #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+        #[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
         #[derive(Clone)]
         struct Acc([u64; ACC_NB]);
     } else if #[cfg(target_feature = "sse2")] {
         #[repr(align(16))]
         #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+        #[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
         #[derive(Clone)]
         struct Acc([u64; ACC_NB]);
     } else {
         #[repr(align(8))]
         #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+        #[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
         #[derive(Clone)]
         struct Acc([u64; ACC_NB]);
     }
@@ -848,6 +855,7 @@ const_assert_eq!(INTERNAL_BUFFER_SIZE % STRIPE_LEN, 0);
 
 #[repr(align(64))]
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 #[derive(Clone)]
 struct State {
     acc: Acc,
@@ -859,6 +867,7 @@ struct State {
 }
 
 #[cfg_attr(feature = "serialize", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 #[derive(Clone)]
 enum With {
     Default(Secret),


### PR DESCRIPTION
I have added the optional derives for the mem-dbg crate, guarded behind a feature flag 'mem-dbg'.

This is needed as several libraries I need to run benchmarks on use this crate as part of their struct. Adding this derives makes it simple to compare the memory requirements of different libraries. Cheers!