### PR TITLE
Update rand to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ check-cfg = [
 ]
 
 [dependencies]
-rand = { version = "0.8.0", optional = true, default-features = false, features = ["std", "std_rng"] }
+rand = { version = "0.9.0", optional = true, default-features = false, features = ["std", "std_rng", "thread_rng"] }
 serde = { version = "1.0.0", optional = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Using the thread rng is now gated by the `thread_rng` feature.